### PR TITLE
Fix quotes in report-results.py

### DIFF
--- a/01_resultmodel/report-results.py
+++ b/01_resultmodel/report-results.py
@@ -32,7 +32,7 @@ class TestFinder(ResultVisitor):
             "NOT RUN": "NOT RUN",
             "NOT SET": "❓ NOT SET",
              }
-        self.f.write(f"| {test.name} | {status_emoji.get(test.status, "unknown")} | {test.elapsed_time.total_seconds()} |\n")
+        self.f.write(f"| {test.name} | {status_emoji.get(test.status, 'unknown')} | {test.elapsed_time.total_seconds()} |\n")
 
     def end_suite(self,suite):
         if suite.tests:


### PR DESCRIPTION
With Python 3.10.12 there is a parsing error on that line. To fix the parsing error in the code, I would replace the double quotes around "unknown" with single quotes